### PR TITLE
Fix createuser expiry parameter in HWID callback

### DIFF
--- a/src/buttons/createuser_hwid.ts
+++ b/src/buttons/createuser_hwid.ts
@@ -1,6 +1,6 @@
 import { Context } from "grammy";
 import { type Execute } from "../interfaces/Button";
-import { GetSellerKey, Request } from "../utilities/session";
+import { Request } from "../utilities/session";
 import { stateManager } from "../utilities/state";
 
 // Store user creation data per userId
@@ -51,7 +51,7 @@ export const execute: Execute = async (ctx: Context, bot, args) => {
     type: "adduser",
     user: userData.username,
     pass: userData.password,
-    expiration: userData.expiration,
+    expiry: userData.expiration.toString(),
     hwidAffected: hwidAffected,
   });
 


### PR DESCRIPTION
## Summary
Fix the /createuser button callback to send the KeyAuth adduser expiry field using the documented \ query parameter instead of \.

## Problem
After entering a valid number of days and clicking the HWID option, the bot called the API with the wrong field name, which caused KeyAuth to return:

> Expiry not set correctly, must be number of days

## Changes
- change the createuser HWID callback request from \ to \
- send the value as a string to match the API contract
- remove the unused \ import in the callback file

## Testing
- verified the pushed diff only changes \
- local TypeScript check is currently not a reliable signal because the repo already has unrelated baseline typing/environment errors