### PR TITLE
Set default subscription on user creation

### DIFF
--- a/src/buttons/createuser_hwid.ts
+++ b/src/buttons/createuser_hwid.ts
@@ -50,6 +50,7 @@ export const execute: Execute = async (ctx: Context, bot, args) => {
     sellerkey: userData.sellerKey,
     type: "adduser",
     user: userData.username,
+    sub: "default",
     pass: userData.password,
     expiry: userData.expiration.toString(),
     hwidAffected: hwidAffected,

--- a/src/commands/users/createuser.ts
+++ b/src/commands/users/createuser.ts
@@ -144,6 +144,7 @@ async function createUser(
     sellerkey: userData.sellerKey,
     type: "adduser",
     user: userData.username,
+    sub: "default",
     pass: userData.password,
     expiry: userData.expiration.toString(),
     hwidAffected: hwidAffected,


### PR DESCRIPTION
## Summary
- Add `sub: "default"` to the add-user payload in both user creation paths.
- Ensures newly created users are assigned the default subscription consistently.

## Testing
- Not run (PR content generation only).
- Verified the diff updates both `src/commands/users/createuser.ts` and `src/buttons/createuser_hwid.ts`.