### PR TITLE
Add subscription selection to create user flow

### DIFF
--- a/src/buttons/createuser_hwid.ts
+++ b/src/buttons/createuser_hwid.ts
@@ -6,7 +6,13 @@ import { stateManager } from "../utilities/state";
 // Store user creation data per userId
 const userCreationData = new Map<
   number,
-  { sellerKey: string; username: string; password: string; expiration: number }
+  {
+    sellerKey: string;
+    username: string;
+    password: string;
+    expiration: number;
+    subscription: string;
+  }
 >();
 
 export function setUserCreationData(
@@ -16,6 +22,7 @@ export function setUserCreationData(
     username: string;
     password: string;
     expiration: number;
+    subscription: string;
   },
 ) {
   userCreationData.set(userId, data);
@@ -50,7 +57,7 @@ export const execute: Execute = async (ctx: Context, bot, args) => {
     sellerkey: userData.sellerKey,
     type: "adduser",
     user: userData.username,
-    sub: "default",
+    sub: userData.subscription,
     pass: userData.password,
     expiry: userData.expiration.toString(),
     hwidAffected: hwidAffected,

--- a/src/commands/users/createuser.ts
+++ b/src/commands/users/createuser.ts
@@ -8,7 +8,13 @@ import { setUserCreationData } from "../../buttons/createuser_hwid";
 // Store user creation data per userId
 const userCreationData = new Map<
   number,
-  { sellerKey: string; username: string; password: string; expiration: number }
+  {
+    sellerKey: string;
+    username: string;
+    password: string;
+    expiration: number;
+    subscription: string;
+  }
 >();
 
 export const name: string = "createuser";
@@ -24,6 +30,7 @@ export const execute: Execute = async (ctx, bot) => {
     username: "",
     password: "",
     expiration: 0,
+    subscription: "default",
   });
 
   await ctx.reply(`Please provide the username for the new user.`);
@@ -99,6 +106,31 @@ async function handleExpiration(ctx: Context): Promise<void> {
   const userData = userCreationData.get(userId);
   if (userData) {
     userData.expiration = expirationParsed;
+  }
+
+  await ctx.reply(
+    "Please provide the subscription name for the new user. Send default to use the default subscription.",
+  );
+
+  stateManager.setWaitingForResponse(
+    userId,
+    "createuser_subscription",
+    handleSubscription,
+  );
+}
+
+async function handleSubscription(ctx: Context): Promise<void> {
+  const subscriptionRaw = ctx.message?.text?.trim();
+  const userId = ctx.from?.id;
+
+  if (!subscriptionRaw || !userId) {
+    await ctx.reply("Please provide a valid subscription name.");
+    return;
+  }
+
+  const userData = userCreationData.get(userId);
+  if (userData) {
+    userData.subscription = subscriptionRaw;
     // Store in the button module for callback handling
     setUserCreationData(userId, userData);
   }
@@ -144,7 +176,7 @@ async function createUser(
     sellerkey: userData.sellerKey,
     type: "adduser",
     user: userData.username,
-    sub: "default",
+    sub: userData.subscription,
     pass: userData.password,
     expiry: userData.expiration.toString(),
     hwidAffected: hwidAffected,


### PR DESCRIPTION
## Summary
- Added subscription tracking to the create-user flow so new users are created with an explicit `sub` value.
- Prompted the operator for a subscription name after expiration is entered, with `default` as the fallback value.
- Passed the selected subscription through both the command flow and the HWID callback path.

## Testing
- Not run
- Checked the diff to confirm `sub` is included in both add-user request paths.
- Verified the create-user flow now collects username, password, expiration, and subscription in sequence.